### PR TITLE
Update nodesource repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.9
 ENV PYTHONUNBUFFERED 1
 
-#non-alpine install of npm
-RUN apt-get update && apt-get install -y \
-    && apt-get -yq install curl gnupg ca-certificates\
-    && curl -L https://deb.nodesource.com/setup_16.x | bash \
-    && apt-get install -yq nodejs npm
+# install node
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
 # app user variables
 ARG user=app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
 FROM python:3.9
-
-# ensuring there's no residue in case of failure
 ENV PYTHONUNBUFFERED 1
-
-# alpine patching - postgres dependencies and bridging
-#RUN apk add --update --no-cache postgresql-client jpeg-dev
-#RUN apk add --update --no-cache --virtual .tmp-build-deps \
-#    gcc libc-dev linux-headers postgresql-dev musl-dev zlib zlib-dev
-#RUN apk add libffi-dev
-
-# alpine NPM
-#RUN apk add --update --no-cache npm
 
 #non-alpine install of npm
 RUN apt-get update && apt-get install -y \
@@ -29,18 +18,17 @@ ARG USERID
 ARG GROUPID
 
 # create group and user with home directory
-# alpine version: RUN addgroup -g $GROUPID $group && adduser -u $USERID -G $group -h $home -D $user
 RUN addgroup --gid $GROUPID $group
 RUN adduser -u $USERID --ingroup $group --home $home --disabled-password $user
 
 # switch to new user
 USER $user
 
-#create directory and copy over the code onto the container
+# create directory and copy over the code onto the container
 RUN mkdir $project
 COPY . $project/
 
-# Create local environment and use as variable
+# create local environment and use as variable
 ENV VIRTUAL_ENV=$home/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -49,9 +37,6 @@ RUN pip install -r $project/requirements.txt
 
 # come back as root to clean up
 USER root
-
-# no need for temp dependencies anymore
-# RUN apk del .tmp-build-deps
 
 # all future commands should run as the user in river directory
 USER $user


### PR DESCRIPTION
We use nodesource.com node.js distributions for our Docker setup. They have migrated to a new system, which this PR follows.

More info: https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository

Note: we should probably remove the virtualenv installation from Dockerfile soon and maybe find a better way to deal with the user and `id -u` setup that's happening in Dockerfile/docker-compose.yml. It's still not 100% clear to me what's the motivation behind it so I'm not sure how to test alternatives.