### PR TITLE
Move scrolling out of drawer logic into contents

### DIFF
--- a/templates/messaging/chatbox_snippet.html
+++ b/templates/messaging/chatbox_snippet.html
@@ -93,8 +93,10 @@
                     if (!uploadCheckbox.classList.contains('hidden')) {
                         uploadCheckbox.classList.add('hidden')
                     }
-                    const elem = document.getElementById(formId).closest('.drawer-contents')
+                    // We want to scroll the messages list to the bottom
+                    const elem = document.getElementById(targetId)
                     if (elem) {
+                        window.elem = elem
                         scrollToBottom(elem)
                     }
                 }

--- a/templates/messaging/messages.html
+++ b/templates/messaging/messages.html
@@ -25,7 +25,7 @@
     {% else %}
 
         <div id="messages-{{ unique_id }}"
-             class="mx-4.5 max-height-[50vh]"
+             class="mx-4.5 max-h-[50vh] overflow-y-auto"
              x-setup-message-refresh="[`{{ message_count_url }}`, `{{ message_list_url }}`, `messages-{{ unique_id }}`]"
              :class="selected && 'selected'"
           >

--- a/templates/messaging/ts/messaging.ts
+++ b/templates/messaging/ts/messaging.ts
@@ -48,7 +48,7 @@ function setupMessageRefresh(messageCountURL: string, messageListURL: string, me
 
     async function refreshMessageList() {
         await htmx.ajax('GET', messageListURL, `#${messageListTargetId}`)
-        const elem = document.getElementById(messageListTargetId)?.closest('.drawer-contents')
+        const elem = document.getElementById(messageListTargetId)
         if (elem) {
             scrollToBottom(elem)
         }

--- a/templates/partials/drawer-river.html
+++ b/templates/partials/drawer-river.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <section x-data="{selected:{{ selected }}}" class="{# sticky #} top-0 bg-white bg-drawer-blue"
-     :class="selected && 'rounded-t-xl'" x-bind:style="selected==1?'max-height:100vh;':''">
+     :class="selected && 'rounded-t-xl'">
     <div class="transition-all">
         {% if not locked %}
             <button class="w-full py-4.5 px-4.5" type="button" id="{{ id }}-button"
@@ -29,8 +29,8 @@
         </button>
     </div>
     {% if not locked %} {% comment %} don't load if not needed, might contain requests to pages that don't exist {% endcomment %}
-        <div class="drawer-contents px-4 relative overflow-hidden overflow-y-auto transition-all max-h-0 duration-700"
-             style="" id="{{ id }}" x-ref={{ reference }} x-bind:style="selected==1?'max-height:75vh;':''" @click="selected ? 1 : scrollToBottom($el.child);">
+        <div class="drawer-contents px-4 relative overflow-hidden transition-all duration-700"
+             style="" id="{{ id }}" x-ref={{ reference }} x-bind:style="selected==1?'':'max-height:0;'" @click="selected ? 1 : scrollToBottom($el.child);">
             {% block drawer_content %}
                 # Drawer contents
             {% endblock %}

--- a/templates/river/description.html
+++ b/templates/river/description.html
@@ -2,7 +2,7 @@
 
 {% block drawer_content %}
     {% include "partials/vertical-spacer.html" with space="3" %}
-    <p id="river-description" class="font-garamond-500 text-base leading-5 text-black-text">
+    <p id="river-description" class="font-garamond-500 text-base leading-5 text-black-text overflow-y-auto max-h-[100vh]">
         {{ object.description }}
     </p>
     {% include "partials/vertical-spacer.html" with space="3" %}

--- a/templates/river/swimmers_list.html
+++ b/templates/river/swimmers_list.html
@@ -1,6 +1,6 @@
 {% load custom_filters %}
 
-<div class="flex flex-col gap-3" id="swimmers">
+<div class="flex flex-col gap-3 overflow-y-auto max-h-[100vh]" id="swimmers">
     {% for member in members %}
         <div x-data="{ open: false }">
             <div class="flex justify-between items-center">


### PR DESCRIPTION
As part of adding tasks, we need to not scroll the entire drawer contents, but just specific bits, so this PR:
- removes scrolling from drawer contents
- implements it separately for
  - swimmers list
  - river description
  - chat