### PR TITLE
Export Postgres port on docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,8 @@ services:
     volumes:
       - /var/lib/postgres
     restart: always
+    ports:
+      - "5432:5432"
 
   # redis-overcommit-on-host
   redis-overcommit:


### PR DESCRIPTION
I thought maybe we export the Postgres port on host to easier have direct access to the database.