### PR TITLE
Fix docker volume definition

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     env_file:
       - variables.env
     volumes:
-      - /var/lib/postgres
+      - dbdata:/var/lib/postgres
     restart: always
     ports:
       - "5432:5432"
@@ -59,3 +59,6 @@ services:
       - db_pg
       - redis
       - app
+
+volumes:
+  dbdata:


### PR DESCRIPTION
This changes the docker volume definition as a named volume. Without a label, an anonymous volume gets erased every time we rebuild our containers. This is not ideal as we want to change our Dockerfile without worrying losing data.