### PR TITLE
More responsiveness

### DIFF
--- a/apps/core/templatetags/custom_tags.py
+++ b/apps/core/templatetags/custom_tags.py
@@ -10,7 +10,7 @@ DJANGO_VITE_DEV_MODE = getattr(settings, "DJANGO_VITE_DEV_MODE", False)
 @register.simple_tag
 @mark_safe
 def sfs_vite_prevent_unstyled_flash(*args):
-    """Prevent a flash on unstyled html for full page loads in dev mode
+    """Prevent a flash of unstyled html for full page loads in dev mode
 
     Without this, as the CSS is loaded with vite via js module,
     there is a delay between when the browser has received all the

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -105,8 +105,8 @@ def dashboard(request: HttpRequest) -> HttpResponse:
 
     for river in all_rivers:
         try:
-            members = RiverMembership.objects.get(user=request.user, river=river)
-            river.membership = members
+            membership = RiverMembership.objects.get(user=request.user, river=river)
+            river.membership = membership
             river.started_months_ago = river.get_started_months_ago
             river.current_stage = river.get_current_stage_string
             rivers.append(river)

--- a/sfs/assets/css/sfs.css
+++ b/sfs/assets/css/sfs.css
@@ -49,24 +49,24 @@
 }
 
 /* flickity carousel dots */
-/* position dots in carousel */
-.flickity-page-dots {
-    bottom: 500px;
-}
-
-/* circles */
-.flickity-page-dots .dot {
-    width: 6px;
-    height: 6px;
+button.flickity-page-dot {
+    width: 8px;
+    height: 8px;
     opacity: 1;
-    background: rgba(0, 0, 0, 0.30);
+    background-color: rgba(0, 0, 0, 0.30);
     border: none;
     margin: 0 2px;
 }
 
 /* fill-in selected dot */
-.flickity-page-dots .dot.is-selected {
+button.flickity-page-dot.is-selected {
     background: #9759FF; /* purple */
+}
+
+/* remove the focus style */
+button.flickity-page-dot:focus {
+    outline: none;
+    box-shadow: none;
 }
 
 /* clears the ‘X’ from Internet Explorer */

--- a/sfs/assets/css/tailwind.css
+++ b/sfs/assets/css/tailwind.css
@@ -84,6 +84,13 @@
         focus:text-black-text focus:border-purple focus:ring-0
         borken:border-red-important focus:borken:ring-red-important
     }
+
+    /* When browser has autocomplete available it changes the colour, this switches it back to our intended colour */
+    input.input-text:-webkit-autofill {
+        transition: background-color 5000s ease-in-out 0s;
+        box-shadow: inset 0 0 40px 40px rgba(229, 241, 248, 1);
+    }
+
     .input-text-invalid {
         @apply invalid:border-red-important focus:invalid:ring-red-important
     }

--- a/sfs/assets/css/tailwind.css
+++ b/sfs/assets/css/tailwind.css
@@ -11,7 +11,7 @@
     /* menu titles ------------------------------ */
     .text-title { /* mobile 19/34 desktop 26/34 */
         @apply font-kanit-500 text-black/75 text-[19px] leading-6
-        lg:text-[26px] lg:leading-[34px]
+        lg:text-[26px] lg:leading-[34px] relative
     }
     /* HEADER ------------------------------ */
     .text-header { /* mobile 10/Auto desktop 12/Auto */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,6 +42,11 @@ export default {
     ],
     theme: {
         extend: {
+            screens: {
+                // Our definition of desktop
+                // Ensure it's the same as defined in screen.ts
+                desktop: '1024px',
+            },
             colors: {
                 transparent: "transparent",
                 current: "currentColor",

--- a/templates/base.html
+++ b/templates/base.html
@@ -43,7 +43,7 @@
 >
 </div>
 
-<section class="block bg-white" :class="menu && 'blur'">
+<section class="block bg-white">
     {% wagtailuserbar %}
 
     {% block content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,6 @@
 
 </head>
 
-{#<body class="antialiased w-full sm:bg-black/20 sm:flex sm:flex-col sm:items-center" x-data="{ menu: false }">#}
 <body class="antialiased w-full " x-data="{ menu: false }">
 
 {% comment %} URL-dependent navbar {% endcomment %}
@@ -44,8 +43,7 @@
 >
 </div>
 
-{#<section class="block bg-white sm:w-[360px]" :class="{'hidden': menu == true}">#}
-<section class="block bg-white" :class="{'hidden': menu == true}">
+<section class="block bg-white" :class="menu && 'blur'">
     {% wagtailuserbar %}
 
     {% block content %}

--- a/templates/dashboard/dashboard.html
+++ b/templates/dashboard/dashboard.html
@@ -53,16 +53,23 @@
     {% include "dashboard/partials/notifications.html" with title="Notifications" reference="notifications" %}
 {% endcomment %}
 
-    <div class="lg:flex w-full lg:pb-9">
+    <div class="desktop:flex w-full lg:pb-9 justify-center">
         {# Messages #}
         {#  Call to action partial, replace URL variable  #}
         {% url 'account_all_chats' as the_url %}
+        <div class="bg-yellow grow"></div>
         {% include "partials/call-to-action.html" with main="Continue the conversations" button="View messages" url=the_url info="" bg="bg-yellow" %}
 
         {#  Call to action partial, replace URL variable  #}
         {% if request.user.post_code.area.name != 'Other' %}
+            <div class="bg-yellow w-24"></div>
+            <div class="bg-resources-two w-24"></div>
+
             {% url 'spring' request.user.post_code.area.name as the_url %}
             {% include "partials/call-to-action.html" with main="Ready to swim?" button="Get involved" url=the_url info="" bg="bg-resources-two" %}
+            <div class="bg-resources-two grow"></div>
+        {% else %}
+            <div class="bg-yellow grow"></div>
         {% endif %}
     </div>
 
@@ -74,7 +81,7 @@
       {% endif %}
     {% endcomment %}
 
-    <div class="max-w-screen-xl lg:mx-auto">
+    <div class="max-w-screen-desktop mx-auto">
         {% include "dashboard/partials/get_in_touch.html" with title="Get in touch" reference="get_in_touch" %}
     </div>
 

--- a/templates/dashboard/partials/get_in_touch.html
+++ b/templates/dashboard/partials/get_in_touch.html
@@ -2,8 +2,8 @@
 
 {% block drawer_content %}
 <div id="get-in-touch-content">
-    <form class="grid grid-cols-2 gap-4" hx-post="/dashboard/contact/" hx-trigger="submit">
-    {% include "dashboard/partials/get_in_touch_form.html" %}
+    <form hx-post="/dashboard/contact/" hx-trigger="submit">
+        {% include "dashboard/partials/get_in_touch_form.html" %}
     </form>
 </div>
 {% endblock %}

--- a/templates/dashboard/partials/get_in_touch_form.html
+++ b/templates/dashboard/partials/get_in_touch_form.html
@@ -1,31 +1,46 @@
-<div>
-    <div class="h-9"></div>
-    <div>
-        <label for="subject" class="block pb-2.5 uppercase font-kanit-600 font-medium text-xxs tracking-widest text-black-text">
-            Subject
-        </label>
-        <select id="subject" name="subject" class="input-text {% if style == 'primary_colour' %}bg-white{% endif %}" tabindex="1">
-            <option value="resources">Suggest resources</option>
-            <option value="feedback">Send your feedback</option>
-            <option value="rollout">Enquire about roll out in your area</option>
-            <option value="bug">Report a bug</option>
-            {% if user.postcode_changes < 1 %}
-                <option value="postcode">Change your postcode</option>
-            {% endif %}
-            <option value="other">Other</option>
-        </select>
+<div class="flex flex-col desktop:flex-row gap-6">
+    <div class="basis-1/2 flex flex-col gap-6">
+        <div>
+            <label for="subject" class="block pb-2.5 uppercase font-kanit-600 font-medium text-xxs tracking-widest text-black-text">
+                Subject
+            </label>
+            <select id="subject" name="subject" class="input-text {% if style == 'primary_colour' %}bg-white{% endif %}" tabindex="1">
+                <option value="resources">Suggest resources</option>
+                <option value="feedback">Send your feedback</option>
+                <option value="rollout">Enquire about roll out in your area</option>
+                <option value="bug">Report a bug</option>
+                {% if user.postcode_changes < 1 %}
+                    <option value="postcode">Change your postcode</option>
+                {% endif %}
+                <option value="other">Other</option>
+            </select>
+        </div>
+
+        <div>
+            <label for="email" class="block pb-2.5 uppercase font-kanit-600 font-medium text-xxs tracking-widest text-black-text">
+                Email
+            </label>
+            <input type="email" name="email" id="email" class="input-text {% if style == 'primary_colour' %}bg-white{% endif %}" tabindex="2" required>
+        </div>
+
+        <div class="hidden desktop:block">
+            <button class="button {% if style == 'primary_colour' %}button-on-colour{% else %}button-on-white{% endif %}" tabindex="4" type="submit">Send</button>
+        </div>
     </div>
 
-    <div class="h-9"></div>
-    <div>
-        <label for="email" class="block pb-2.5 uppercase font-kanit-600 font-medium text-xxs tracking-widest text-black-text">
-            Email
+    <div class="basis-1/2">
+        <label for="message" class="block pb-2.5 uppercase font-kanit-600 font-medium text-xxs tracking-widest text-black-text">
+            Message
         </label>
-        <input type="email" name="email" id="email" class="input-text {% if style == 'primary_colour' %}bg-white{% endif %}" tabindex="2" required>
+        <textarea name="message" id="message" cols="30" rows="12" class="input-text {% if style == 'primary_colour' %}bg-white{% endif %}" tabindex="3"></textarea>
     </div>
 
-    {% if form.errors %}
-    <div class="h-9"></div>
+    <div class="desktop:hidden">
+        <button class="button {% if style == 'primary_colour' %}button-on-colour{% else %}button-on-white{% endif %}" tabindex="4" type="submit">Send</button>
+    </div>
+</div>
+
+{% if form.errors %}
     <div class="text-body bg-red-important/30 p-4 px-6">
         <div>
             {% for field, errors in form.errors.items %}
@@ -39,18 +54,4 @@
             {% endfor %}
         </div>
     </div>
-    {% endif %}
-
-    <div class="h-9"></div>
-    <button class="button {% if style == 'primary_colour' %}button-on-colour{% else %}button-on-white{% endif %}" tabindex="4" type="submit">Send</button>
-</div>
-
-<div>
-    <div class="h-9"></div>
-    <div>
-        <label for="message" class="block pb-2.5 uppercase font-kanit-600 font-medium text-xxs tracking-widest text-black-text">
-            Message
-        </label>
-        <textarea name="message" id="message" cols="30" rows="12" class="input-text {% if style == 'primary_colour' %}bg-white{% endif %}" tabindex="3"></textarea>
-    </div>
-</div>
+{% endif %}

--- a/templates/dashboard/partials/rivers.html
+++ b/templates/dashboard/partials/rivers.html
@@ -44,17 +44,11 @@
                 {#  Your status #}
                 <div class="w-1/2">
                     <p class="text-black/30 pb-0.5">Your status</p>
-                    {% for member in river.members %}
-                        {% if member.starter %}
-                            <p>
-                                {% if member.user == request.user %}
-                                    River Starter
-                                {% else %}
-                                    Swimmer
-                                {% endif %}
-                            </p>
-                        {% endif %}
-                    {% endfor %}
+                    {% if river.membership.starter %}
+                        River Starter
+                    {% else %}
+                        Swimmer
+                    {% endif %}
                 </div>
                 {#  River stage #}
                 <div class="w-1/2">

--- a/templates/landing/landing.html
+++ b/templates/landing/landing.html
@@ -29,11 +29,11 @@
 
         {% include "partials/vertical-spacer.html" with space="6" %}
 
-        <h1 class="text-large text-center mx-auto sm:max-w-md">Welcome to a project management platform where your
+        <h1 class="text-large text-center mx-auto max-w-screen-desktop desktop:text-3xl">Welcome to a project management platform where your
             community collaborates and gets stuff done!</h1>
         {% include "partials/vertical-spacer.html" with space="9" %}
 
-        <div class="-mx-4.5 relative h-auto min-h-[180px] overflow-hidden sm:h-auto sm:h-12">
+        <div class="-mx-4.5 relative overflow-hidden h-auto max-h-72">
             <div class="relative w-full z-10 sm:-m-1 sm:w-[101vw]">
                 <video class="w-full object-cover object-center sm:mt-[-280px]" autoplay muted loop>
                     <source src="{% static 'images/landing/shared_futures_waters.mp4' %}" type="video/mp4">
@@ -41,7 +41,7 @@
                     Your browser does not support the video tag.
                 </video>
             </div>
-            <div class="h-1/2 z-20 absolute top-0 left-0 w-full h-full flex flex-row justify-center items-center">
+            <div class="z-20 absolute top-0 left-0 w-full h-full flex flex-row justify-center items-center">
                 {% include "partials/button.html" with url=signup_url style="primary_colour" button="Sign up" %}
                 {% include "partials/horizontal-spacer.html" with space="4" %}
                 {% include "partials/button.html" with url=login_url style="primary_colour" button="Log in" %}
@@ -50,7 +50,7 @@
 
         {% include "partials/vertical-spacer.html" with space="9" %}
 
-        <div class="sm:max-w-screen-xl mx-auto">
+        <div class="max-w-screen-desktop mx-auto">
             {% include "landing/section-heading.html" with title="What Shared Futures offers" %}
             {% include "partials/vertical-spacer.html" with space="9" %}
             {% include "landing/tabbed-resources/index.html" %}
@@ -72,7 +72,7 @@
         {% include "partials/vertical-spacer.html" with space="9" %}
 
         {% url 'resources' as resources_url %}
-        <div class="-mx-4.5">
+        <div class="-mx-4.5 desktop:flex">
             {% include "partials/call-to-action.html" with main="Would you like to find out what services and resources are available in your area?" button="See resources" url=resources_url info="" bg="bg-resources-two" %}
             {% include "partials/call-to-action.html" with main="Do you have a project in mind you would like to find like minded people to deliver?" button="Sign up" url=signup_url info="" bg="bg-yellow" %}
         </div>
@@ -85,22 +85,22 @@
 
         {% include "partials/vertical-spacer.html" with space="3" %}
         <div class="bg-blue-pale -mx-4.5">
-            <div class="p-4.5">
+            <div class="p-4.5 w-full max-w-screen-desktop mx-auto">
                 {% include "partials/vertical-spacer.html" with space="6" %}
                 {% include "landing/section-heading.html" with title="get in touch 📧" %}
                 {% include "partials/vertical-spacer.html" with space="9" %}
 
-                <div class="lg:flex lg:justify-center lg:gap-6">
-                    <form class="grid grid-cols-2 gap-4" hx-post="/dashboard/contact/" hx-trigger="submit">
-                        {% include "dashboard/partials/get_in_touch_form.html" with style="primary_colour" %}
-                    </form>
-                </div>
+                <form class="" hx-post="/dashboard/contact/" hx-trigger="submit">
+                    {% include "dashboard/partials/get_in_touch_form.html" with style="primary_colour" %}
+                </form>
 
                 {% include "partials/vertical-spacer.html" with space="4.5" %}
             </div>
         </div>
 
-        {% include "partials/footer-text.html" %}
+        <div class="p-4.5 max-w-screen-desktop mx-auto">
+            {% include "partials/footer-text.html" %}
+        </div>
     </div>
 
 {% endblock content %}

--- a/templates/landing/landing.html
+++ b/templates/landing/landing.html
@@ -29,7 +29,7 @@
 
         {% include "partials/vertical-spacer.html" with space="6" %}
 
-        <h1 class="text-large text-center mx-auto max-w-screen-desktop desktop:text-3xl">Welcome to a project management platform where your
+        <h1 class="text-large text-center px-10 mx-auto max-w-screen-desktop desktop:text-3xl">Welcome to a project management platform where your
             community collaborates and gets stuff done!</h1>
         {% include "partials/vertical-spacer.html" with space="9" %}
 

--- a/templates/landing/landing.html
+++ b/templates/landing/landing.html
@@ -72,9 +72,14 @@
         {% include "partials/vertical-spacer.html" with space="9" %}
 
         {% url 'resources' as resources_url %}
-        <div class="-mx-4.5 desktop:flex">
+        <div class="-mx-4.5 desktop:flex justify-center">
+            <div class="bg-resources-two grow"></div>
             {% include "partials/call-to-action.html" with main="Would you like to find out what services and resources are available in your area?" button="See resources" url=resources_url info="" bg="bg-resources-two" %}
+            <div class="bg-resources-two w-12"></div>
+
+            <div class="bg-yellow w-12"></div>
             {% include "partials/call-to-action.html" with main="Do you have a project in mind you would like to find like minded people to deliver?" button="Sign up" url=signup_url info="" bg="bg-yellow" %}
+            <div class="bg-yellow grow"></div>
         </div>
 
         {% include "partials/vertical-spacer.html" with space="9" %}
@@ -90,7 +95,7 @@
                 {% include "landing/section-heading.html" with title="get in touch 📧" %}
                 {% include "partials/vertical-spacer.html" with space="9" %}
 
-                <form class="" hx-post="/dashboard/contact/" hx-trigger="submit">
+                <form hx-post="/dashboard/contact/" hx-trigger="submit">
                     {% include "dashboard/partials/get_in_touch_form.html" with style="primary_colour" %}
                 </form>
 

--- a/templates/landing/tabbed-resources/index.html
+++ b/templates/landing/tabbed-resources/index.html
@@ -1,8 +1,8 @@
 {% load static %}
 
-{% with li_class="rounded-[50px_50px_0px_0px] text-center px-6 h-[48px] flex items-center justify-center sm:w-1/3 cursor-pointer" %}
+{% with li_class="rounded-[50px_50px_0px_0px] text-center px-8 h-[48px] flex items-center justify-center cursor-pointer" %}
     <div x-data="{ openTab: 'one' }" class="-mx-4.5 ">
-        <ul class="flex flex-start sm:px-24 sm:max-w-4xl sm:mx-auto">
+        <ul class="flex flex-start">
             <li @click="openTab = 'one'" class="{{ li_class }} bg-resources-one">
                 {% include "landing/tabbed-resources/title.html" with title="Collaborate" %}
             </li>

--- a/templates/landing/tabbed-resources/index.html
+++ b/templates/landing/tabbed-resources/index.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-{% with li_class="rounded-[50px_50px_0px_0px] text-center px-6 h-[48px] flex items-center justify-center sm:w-1/3" %}
+{% with li_class="rounded-[50px_50px_0px_0px] text-center px-6 h-[48px] flex items-center justify-center sm:w-1/3 cursor-pointer" %}
     <div x-data="{ openTab: 'one' }" class="-mx-4.5 ">
         <ul class="flex flex-start sm:px-24 sm:max-w-4xl sm:mx-auto">
             <li @click="openTab = 'one'" class="{{ li_class }} bg-resources-one">

--- a/templates/messaging/chatbox_snippet.html
+++ b/templates/messaging/chatbox_snippet.html
@@ -10,11 +10,11 @@
           hx-trigger="click[validateChat('{{ unique_id }}')] from:#chat-button-{{ unique_id }}, keydown[shiftKey&&keyCode==13&&validateChat('{{ unique_id }}')] from:body, keydown[ctrlKey&&keyCode==13&&validateChat('{{ unique_id }}')] from:body"
           id="chat-form-{{ unique_id }}"
           x-init="setTimeout(() => setupResetAfterRequest('messages-{{ unique_id }}', 'chat-form-{{ unique_id }}', 'upload-ready-{{ unique_id }}'), 1000)"
-          class="p-4.5 m-0 sticky bottom-0 backdrop-blur-sm bg-[linear-gradient(180deg,_#F2000000_1%,_#FFFFFF_25%)] sm:w-[360px]">
+          class="p-4.5 m-0 sticky bottom-0 backdrop-blur-sm bg-[linear-gradient(180deg,_#F2000000_1%,_#FFFFFF_25%)]">
         {% csrf_token %}
 
 
-        <div class="text-meta invisible max-w-full">
+        <div class="text-meta hidden max-w-full">
             <input type="file" name=file value="file" id="file-{{ unique_id }}"
                    x-init="setTimeout(()=>{checkFileContents($el.id)}, 1000);">
         </div>
@@ -27,7 +27,7 @@
                         but this can be easily circumvented, so you should always validate the uploaded file on the server also.
                     {% endcomment %}
 
-                <label class="cursor-pointer" for="file-{{ unique_id }}">
+                <label class="cursor-pointer w-6 pl-2" for="file-{{ unique_id }}">
                     <svg width="11" height="22" viewBox="0 0 11 22" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M9.5 5V16.5C9.5 18.71 7.71 20.5 5.5 20.5C3.29 20.5 1.5 18.71 1.5 16.5V4C1.5 2.62 2.62 1.5 4 1.5C5.38 1.5 6.5 2.62 6.5 4V14.5C6.5 15.05 6.05 15.5 5.5 15.5C4.95 15.5 4.5 15.05 4.5 14.5V5H3V14.5C3 15.88 4.12 17 5.5 17C6.88 17 8 15.88 8 14.5V4C8 1.79 6.21 0 4 0C1.79 0 0 1.79 0 4V16.5C0 19.54 2.46 22 5.5 22C8.54 22 11 19.54 11 16.5V5H9.5Z"
                               fill="#9759FF"/>
@@ -35,7 +35,7 @@
                 </label>
 
                 <div id="upload-ready-{{ unique_id }}" class="hidden">
-                    <svg class="fill-red-important" width="18" height="14" viewBox="0 0 18 14"
+                    <svg class="fill-correct" width="18" height="14" viewBox="0 0 18 14"
                          xmlns="http://www.w3.org/2000/svg">
                         <path d="M5.91818 10.9511L1.47955 6.75107L0 8.15107L5.91818 13.7511L18.6 1.75107L17.1205 0.351074L5.91818 10.9511Z"/>
                     </svg>
@@ -46,7 +46,6 @@
 
             <div class="w-full"
                  x-init="setTimeout(()=> {createForm('chat-form-{{ unique_id }}', 'upload-ready-{{ unique_id }}', 'file-{{ unique_id }}')}, 500)">
-
 
                     <textarea data-expandable
                               class="input-text h-[50px] max-h-[150px] bg-yellow rounded-xl w-full max-w-full"

--- a/templates/messaging/message_list.html
+++ b/templates/messaging/message_list.html
@@ -4,7 +4,7 @@
 {% include 'messaging/partials/pull_previous.html' %}
 
 {% comment %}{% if page_obj.count > 0 %}{% endcomment %}
-<div x-data="{ overlay: false }">
+<div x-data="{ overlay: false, state: 'initial' }">
     {% for message in page_obj %}
 
         {% if message.sender == system_user %}

--- a/templates/messaging/user_message_snippet.html
+++ b/templates/messaging/user_message_snippet.html
@@ -92,45 +92,60 @@
                     {% if user.is_authenticated and message.sender.display_name != 'salmon' and user in members and not message.hidden %}
 
                         <div class="inline-block">
-
-                            <button
-                                    hx-post="{{ message_post_url }}"
-                                    hx-vals='{"flag": "{{ message.uuid }}"}'
-                                    hx-target="closest .message" hx-swap="outerHTML"
-                                    @click="overlay = ! overlay;">
-
+                            {% if message.uuid in my_flags %}
                                 <svg width="8" height="10" viewBox="0 0 8 10"
                                      xmlns="http://www.w3.org/2000/svg"
-                                        {% if message.uuid in my_flags %}
-                                     class="fill-red-important"
-                                        {% else %}
-                                     class="fill-black/30"
-                                        {% endif %}>
+                                     class="fill-red-important">
                                     <path d="M0 10V0H4.42857L4.78571 1.49254H7.92857V6.86567H4.92857L4.57143 5.37313H0.785714V10H0ZM5.57143 6.04478H7.21429V2.31343H4.21429L3.85714 0.820896H0.785714V4.55224H5.21429L5.57143 6.04478Z"/>
                                 </svg>
-                            </button>
+                            {% else %}
+                                <button @click="overlay = true; state = 'initial';">
+                                    <svg width="8" height="10" viewBox="0 0 8 10"
+                                         xmlns="http://www.w3.org/2000/svg"
+                                         class="fill-black/30">
+                                        <path d="M0 10V0H4.42857L4.78571 1.49254H7.92857V6.86567H4.92857L4.57143 5.37313H0.785714V10H0ZM5.57143 6.04478H7.21429V2.31343H4.21429L3.85714 0.820896H0.785714V4.55224H5.21429L5.57143 6.04478Z"/>
+                                    </svg>
+                                </button>
+                            {% endif %}
 
-
-                            <div :class="overlay || 'hidden'"
-                            >
-                                <section
-                                        class="z-20 flex overflow-hidden justify-center items-center flex-col h-full w-full fixed left-0 top-0 backdrop-blur px-4.5">
+                            <div :class="overlay || 'hidden'">
+                                <section class="z-20 flex overflow-hidden justify-center items-center flex-col h-full w-full fixed left-0 top-0 backdrop-blur px-4.5"
+                                         @click="el => { if (el.target.classList.contains('backdrop-blur')) { overlay = false } }"
+                                         @keyup.escape.window="overlay = false">
                                     {#  White modal background  #}
                                     <div class="w-full bg-white m-2.5 sm:w-[360px]">
                                         <div class="bg-red-important/30 sm:w-[360px]">
                                             <div class="p-2.5">
-                                                <div class="flex flex-col items-center py-9 px-4.5 text-center">
-                                                    <p class="text-large pb-6 normal-case">
-                                                        If three people flag this message then it will be hidden for
-                                                        all users.
-                                                    </p>
-                                                    <div class="flex gap-4.5">
-                                                        <button @click="overlay = ! overlay; $event.preventDefault();"
-                                                                class="button button-on-colour">
-                                                            OK
-                                                        </button>
-
+                                                <div class="flex flex-col items-center py-9 px-4.5 text-center"
+                                                     x-show="state === 'initial'">
+                                                        <p class="text-large pb-6 normal-case">
+                                                            If three people flag this message then it will be hidden for
+                                                            all users.
+                                                        </p>
+                                                        <div class="flex gap-4.5">
+                                                            <button @click.prevent.stop="overlay = ! overlay"
+                                                                    class="button button-on-colour">
+                                                                Cancel
+                                                            </button>
+                                                            <button class="button button-on-colour"
+                                                                    hx-post="{{ message_post_url }}"
+                                                                    hx-vals='{"flag": "{{ message.uuid }}"}'
+                                                                    hx-target="closest .message" hx-swap="outerHTML"
+                                                                    @htmx:after-swap.window="state = 'flagged'">
+                                                                Flag message
+                                                            </button>
+                                                        </div>
                                                     </div>
+                                                </div>
+                                                <div class="flex flex-col items-center py-9 px-4.5 text-center"
+                                                     x-show="state === 'flagged'">
+                                                    <p class="text-large pb-6 normal-case">
+                                                        Message was flagged
+                                                    </p>
+                                                    <button @click.prevent.stop="overlay = false"
+                                                            class="button button-on-colour">
+                                                        OK
+                                                    </button>
                                                 </div>
                                             </div>
                                         </div>

--- a/templates/partials/call-to-action.html
+++ b/templates/partials/call-to-action.html
@@ -1,4 +1,4 @@
-<div class="flex flex-col items-center py-9 px-4.5 text-center {{bg}} sm:mx-0 sm:grow">
+<div class="flex flex-col items-center py-9 px-4.5 text-center {{bg}} sm:mx-0">
 
     <p class="text-large max-w-sm">
         {{ main }}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -67,7 +67,7 @@
 
                 <div x-data="{selected:null}">
                     <button class="w-full p-4 pb-5 flex items-center justify-between" type="button"
-                            @click="selected !== 1 ? selected = 1 : selected = null">
+                            @click.prevent.stop="selected !== 1 ? selected = 1 : selected = null">
                         Springs
                         <div class="w-[12] h-[8] transition duration-500 ease-out"
                              :class="{'-rotate-180': selected}">

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <div class="h-full w-full fixed left-0 top-0 z-50 backdrop-blur bg-blue-blur"
-     x-data="{ open: false, toggle() { this.open = !this.open; menu = !menu } }"
+     x-data="{ open: false, close() { this.open = false; menu = false; }, toggle() { this.open = !this.open; menu = !menu } }"
      x-show="open"
      x-cloak
      @click="toggle()"
@@ -11,7 +11,7 @@
      x-transition:leave="transition ease-in duration-400"
      x-transition:leave-start="opacity-100"
      x-transition:leave-end="opacity-0"
-     @keyup.escape.window="toggle()"
+     @keyup.escape.window="close()"
      x-stop-body-scroll-if="open">
 
     {# Burger-cross icon #}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,35 +1,49 @@
 {% load static %}
 
-<div x-data="{ open: false, toggle() { this.open = ! this.open } }" :class="{'fixed top-0 right-6.5': open == true}"
-     class="w-full max-w-screen-xl mx-auto relative pointer-events-auto z-50">
+<div class="h-full w-full fixed left-0 top-0 z-50 backdrop-blur bg-blue-blur"
+     x-data="{ open: false, toggle() { this.open = !this.open; menu = !menu } }"
+     x-show="open"
+     x-cloak
+     @click="toggle()"
+     x-transition:enter="transition ease-out duration-500"
+     x-transition:enter-start="opacity-0"
+     x-transition:enter-end="opacity-100"
+     x-transition:leave="transition ease-in duration-400"
+     x-transition:leave-start="opacity-100"
+     x-transition:leave-end="opacity-0"
+     @keyup.escape.window="toggle()"
+     x-stop-body-scroll-if="open">
 
-    {#  Burger-cross icon  #}
-    <button class="text-purple flex w-6 h-6 right-3 top-[11px] absolute focus:outline-none z-10"
-            @click="toggle(), menu = !menu">
-        <span class="sr-only">Open main menu</span>
-        <div class="block w-5 absolute left-1/2 top-1/2   transform  -translate-x-1/2 -translate-y-1/2">
-            <span aria-hidden="true"
-                  class="block absolute h-0.5 w-5 bg-current transform transition duration-500 ease-in-out"
-                  :class="{'rotate-45': open, '-translate-y-1.5': !open}"></span>
-            <span aria-hidden="true"
-                  class="block absolute h-0.5 w-5 bg-current transform transition duration-500 ease-in-out"
-                  :class="{'opacity-0': open} "></span>
-            <span aria-hidden="true"
-                  class="block absolute h-0.5 w-5 bg-current transform transition duration-500 ease-in-out"
-                  :class="{'-rotate-45': open, 'translate-y-1.5': !open}"></span>
-        </div>
-    </button>
+    {# Burger-cross icon #}
+    {# Gets put in the header TODO: have a proper header element, not just an h1.text-title #}
+    <template x-teleport="h1.text-title">
+        <button class="text-purple flex w-6 h-6 right-3 top-[11px] absolute focus:outline-none z-10"
+                @click.stop.prevent="toggle()">
+            <span class="sr-only">Open main menu</span>
+            <div class="block w-5 absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
+                <span aria-hidden="true"
+                      class="block absolute h-0.5 w-5 bg-current transform transition duration-500 ease-in-out"
+                      :class="{'rotate-45': open, '-translate-y-1.5': !open}"></span>
+                <span aria-hidden="true"
+                      class="block absolute h-0.5 w-5 bg-current transform transition duration-500 ease-in-out"
+                      :class="{'opacity-0': open} "></span>
+                <span aria-hidden="true"
+                      class="block absolute h-0.5 w-5 bg-current transform transition duration-500 ease-in-out"
+                      :class="{'-rotate-45': open, 'translate-y-1.5': !open}"></span>
+            </div>
+        </button>
+    </template>
 
     {#  Menu window  #}
-    <div x-show="open"
+    <div class="h-screen desktop:fixed desktop:right-0"
+         x-show="open"
+         x-cloak
          x-transition:enter="transition ease-out duration-500"
          x-transition:enter-start="opacity-0"
          x-transition:enter-end="opacity-100"
          x-transition:leave="transition ease-in duration-400"
          x-transition:leave-start="opacity-100"
-         x-transition:leave-end="opacity-0"
-         x-cloak
-         class="h-screen lg:fixed lg:right-0">
+         x-transition:leave-end="opacity-0">
 
         {#  Menu list  #}
         <nav class="w-full min-h-full font-kanit-500 text-xl text-black-text flex flex-col">
@@ -45,9 +59,9 @@
 
                 <li class="p-4 pb-5">
                     {% if user.is_authenticated %}
-                        <a href="{% url 'dashboard' %}" @click="toggle(), menu = !menu">Dashboard</a>
+                        <a href="{% url 'dashboard' %}" @click="toggle()">Dashboard</a>
                     {% else %}
-                        <a href="{% url 'landing' %}" @click="toggle(), menu = !menu">Landing page</a>
+                        <a href="{% url 'landing' %}" @click="toggle()">Landing page</a>
                     {% endif %}
                 </li>
 
@@ -75,22 +89,22 @@
 
                 {% if user.is_authenticated %}
                     <li class="p-4 pb-5">
-                        <a href="{% url 'account_all_chats' %}" @click="toggle(), menu = !menu">Messages</a>
+                        <a href="{% url 'account_all_chats' %}" @click="toggle()">Messages</a>
                     </li>
                     <li class="p-4 pb-5">
-                        <a href="{% url 'account_view' %}" @click="toggle(), menu = !menu">Profile</a>
+                        <a href="{% url 'account_view' %}" @click="toggle()">Profile</a>
                     </li>
                 {% endif %}
 
                 <li class="p-4 pb-5">
-                    <a href="{% url 'resources' %}" @click="toggle(), menu = !menu">Resources</a>
+                    <a href="{% url 'resources' %}" @click="toggle()">Resources</a>
                 </li>
 
                 <li class="p-4 pb-5">
                     {% if user.is_authenticated %}
                         <form method="post" action="{% url 'account_logout' %}">
                             {% csrf_token %}
-                            <button type="submit" @click="toggle(), menu = !menu">
+                            <button type="submit" @click="toggle()">
                                 Log out
                             </button>
                         </form>
@@ -100,7 +114,7 @@
 
             <ul class="p-4 bg-white">
                 <li class="text-meta text-purple font-kanit-600 mr-2.5">
-                    <a href="{% url 'privacy' %}" @click="toggle(), menu = !menu">
+                    <a href="{% url 'privacy' %}" @click="toggle()">
                         Privacy policy
                     </a>
                 </li>

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -46,7 +46,7 @@
          x-transition:leave-end="opacity-0">
 
         {#  Menu list  #}
-        <nav class="w-full min-h-full font-kanit-500 text-xl text-black-text flex flex-col">
+        <nav class="w-full h-full max-h-full font-kanit-500 text-xl text-black-text flex flex-col">
             <h1 class="bg-white p-4 py-2.5 text-purple">
                 Menu
             </h1>

--- a/templates/partials/overlay-river.html
+++ b/templates/partials/overlay-river.html
@@ -14,15 +14,21 @@
 
         <button @click="overlayClose()">close</button>
 
+    There are two modes the closing works:
+
+    1. if you are in an "editing" context (i.e. the river settings page)
+        -> closing will set editing = false
+    2. anything else it will remove the modal element from the DOM
+
 {% endcomment %}
 
 <section class="overlay-river z-20 flex justify-center items-center h-full w-full fixed left-0 top-0 backdrop-blur bg-blue-blur"
-         x-data="{ overlayClose() { $el.remove() } }"
+         x-data="{ overlayClose() { editing ? (editing = false ) : $el.remove() } }"
          x-stop-body-scroll>
 
     {% block river_overlay_extra %}{% endblock %}
 
-    <div class="bg-white mx-2.5 px-5 grow">
+    <div class="bg-white mx-2.5 px-5 grow max-w-xl">
         {% include "partials/vertical-spacer.html" with space="7.5" %}
         {% block overlay_header %}
             <h2 class="text-large text-center w-full">

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -5,7 +5,7 @@
         Shared Futures Space - Dashboard
     </title>
 
-    <h1 class="text-title text-purple px-[18px] py-2.5 max-w-screen-desktop mx-auto">
+    <h1 class="text-title text-purple px-[18px] py-2.5 max-w-screen-xl mx-auto">
         Welcome
         {{ title }}
         {% comment %}
@@ -13,14 +13,14 @@
         {% endcomment %}
     </h1>
 {% elif partial %}
-    <h1 class="text-title text-purple px-[18px] py-2.5 max-w-screen-desktop mx-auto">
+    <h1 class="text-title text-purple px-[18px] py-2.5 max-w-screen-xl mx-auto">
         {{ title }}
     </h1>
 {% elif landing %}
     <title>
         Shared Futures Space
     </title>
-    <div class="flex items-center ml-4.5 max-w-screen-desktop desktop:mx-auto">
+    <div class="flex items-center ml-4.5 max-w-screen-xl desktop:mx-auto">
         <img src="{% static 'images/partner_logos/shared-futures.png' %}" class="h-8">
         <h1 class="text-title text-purple px-3 py-2.5">
             {{ title }}
@@ -38,7 +38,7 @@
         {% endif %}
     </title>
 
-    <h1 class="text-title text-purple px-[18px] py-2.5 w-full max-w-screen-desktop mx-auto">
+    <h1 class="text-title text-purple px-[18px] py-2.5 w-full max-w-screen-xl mx-auto">
         {% if chat_title %}
             {{ title }} {{ chat_title }}
         {% else %}

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -5,7 +5,7 @@
         Shared Futures Space - Dashboard
     </title>
 
-    <h1 class="text-title text-purple px-[18px] py-2.5 lg:py-5 max-w-screen-xl mx-auto">
+    <h1 class="text-title text-purple px-[18px] py-2.5 max-w-screen-desktop mx-auto">
         Welcome
         {{ title }}
         {% comment %}
@@ -13,16 +13,16 @@
         {% endcomment %}
     </h1>
 {% elif partial %}
-    <h1 class="text-title text-purple px-[18px] py-2.5 lg:py-5 max-w-screen-xl mx-auto">
+    <h1 class="text-title text-purple px-[18px] py-2.5 max-w-screen-desktop mx-auto">
         {{ title }}
     </h1>
 {% elif landing %}
     <title>
         Shared Futures Space
     </title>
-    <div class="flex items-center ml-4.5 max-w-screen-xl lg:mx-auto">
+    <div class="flex items-center ml-4.5 max-w-screen-desktop desktop:mx-auto">
         <img src="{% static 'images/partner_logos/shared-futures.png' %}" class="h-8">
-        <h1 class="text-title text-purple px-3 py-2.5 lg:py-5">
+        <h1 class="text-title text-purple px-3 py-2.5">
             {{ title }}
         </h1>
     </div>
@@ -38,7 +38,7 @@
         {% endif %}
     </title>
 
-    <h1 class="text-title text-purple px-[18px] py-2.5 lg:py-5 w-full max-w-screen-xl mx-auto">
+    <h1 class="text-title text-purple px-[18px] py-2.5 w-full max-w-screen-desktop mx-auto">
         {% if chat_title %}
             {{ title }} {{ chat_title }}
         {% else %}

--- a/templates/river/partials/river-description-change.html
+++ b/templates/river/partials/river-description-change.html
@@ -1,66 +1,51 @@
-{% extends "partials/overlay-river.html" %}
+{% extends "partials/overlay-river-closable.html" %}
 {% block overlay_title %}Change River description{% endblock %}
 {% load static %}
 
 {% block river_overlay_content %}
+    <form hx-put="{% url 'edit_river' river.slug %}" hx-target="#river-description" hx-swap="innerHTML"
+          class="mb-0">
 
+        {% csrf_token %}
 
-<section class="z-20 flex justify-center items-center h-full w-full fixed left-0 top-0 backdrop-blur bg-blue-blur">
-    <div class="bg-white mx-2.5 px-5 grow">
-        {% include "partials/vertical-spacer.html" with space="7.5" %}
-        <h2 class="text-large text-center w-full">
-            Change River description
-        </h2>
-        {% include "partials/vertical-spacer.html" with space="6" %}
+        {% include "partials/input-label.html" with for="description" label="New River description" %}
+        <textarea id=river-description-input name=description type=text placeholder="{{ river.description }}"
+                  value=""
+                  class="input-text input-text-invalid"></textarea>
+        {% include "partials/vertical-spacer.html" with space="1.5" %}
+        {% include "partials/input-note.html" with for="title" label="You can change river title until you create the poll" %}
+        {% include "partials/vertical-spacer.html" with space="4.5" %}
+        <div class="flex items-center justify-center">
+            <button x-on:click="editing = !editing"
+                    type="button"
+                    class="button button-on-white">
+                Back
+            </button>
+            {% include "partials/horizontal-spacer.html" with space="4.5" %}
+            {% comment %}
+           {% endcomment %}
+            <button
+                    x-on:click="()=>{
+                    enableBodyScroll();
+                    //remove settings
+                    open = !open;
 
+                    // editing unblock
+                    editing = !editing;
 
-        <form hx-put="{% url 'edit_river' river.slug %}" hx-target="#river-description" hx-swap="innerHTML"
-              class="mb-0">
+                    //aligning input with placeholder in case someone wants to change again
+                    var descriptionInput = document.getElementById('river-description-input')
+                    descriptionInput.placeholder = descriptionInput.value
+                    setTimeout(()=>{
+                        descriptionInput.value = ''
+                    }, 500)
 
-            {% csrf_token %}
+                    }"
+                    type="submit"
+                    class="button button-on-white">
 
-            {% include "partials/input-label.html" with for="description" label="New River description" %}
-            <textarea id=river-description-input name=description type=text placeholder="{{ river.description }}"
-                      value=""
-                      class="input-text input-text-invalid"></textarea>
-            {% include "partials/vertical-spacer.html" with space="1.5" %}
-            {% include "partials/input-note.html" with for="title" label="You can change river title until you create the poll" %}
-            {% include "partials/vertical-spacer.html" with space="4.5" %}
-            <div class="flex items-center justify-center">
-                <button x-on:click="editing = !editing"
-                        type="button"
-                        class="button button-on-white">
-                    Back
-                </button>
-                {% include "partials/horizontal-spacer.html" with space="4.5" %}
-                {% comment %}
-               {% endcomment %}
-                <button
-                        x-on:click="()=>{
-                        enableBodyScroll();
-                        //remove settings
-                        open = !open;
-
-                        // editing unblock
-                        editing = !editing;
-
-                        //aligning input with placeholder in case someone wants to change again
-                        var descriptionInput = document.getElementById('river-description-input')
-                        descriptionInput.placeholder = descriptionInput.value
-                        setTimeout(()=>{
-                            descriptionInput.value = ''
-                        }, 500)
-
-                        }"
-                        type="submit"
-                        class="button button-on-white">
-
-                    Submit
-                </button>
-            </div>
-            {% include "partials/vertical-spacer.html" with space="7.5" %}
-        </form>
-    </div>
-</section>
-
+                Submit
+            </button>
+        </div>
+    </form>
 {% endblock %}

--- a/templates/river/partials/river-image-change.html
+++ b/templates/river/partials/river-image-change.html
@@ -1,4 +1,4 @@
-{% extends "partials/overlay-river.html" %}
+{% extends "partials/overlay-river-closable.html" %}
 {% block overlay_title %}Change River title{% endblock %}
 {% load static %}
 
@@ -26,7 +26,7 @@
 
     {% include "partials/vertical-spacer.html" with space="6" %}
     <div class="flex items-center justify-center">
-        <button x-on:click="()=>{
+        <button @click="()=>{
                                 editing = !editing
                                 document.getElementById('river-image-upload').value = ''
                                 document.getElementById('image-preview').src = ''

--- a/templates/river/partials/river-image-change.html
+++ b/templates/river/partials/river-image-change.html
@@ -1,5 +1,5 @@
 {% extends "partials/overlay-river-closable.html" %}
-{% block overlay_title %}Change River title{% endblock %}
+{% block overlay_title %}Change River image{% endblock %}
 {% load static %}
 
 {% block river_overlay_content %}
@@ -20,8 +20,8 @@
                accept="image/png, image/jpeg, image/webp">
     </div>
     {% include "partials/vertical-spacer.html" with space="6" %}
-    <div class="w-96">
-        <img id="image-preview" class="h-auto max-w-1/3"/>
+    <div class="w-full">
+        <img id="image-preview" class="h-auto"/>
     </div>
 
     {% include "partials/vertical-spacer.html" with space="6" %}
@@ -40,7 +40,7 @@
         {% comment %}
                {% endcomment %}
         <button
-                x-on:click="()=>{
+                @click="()=>{
                         enableBodyScroll();
                         //remove settings
                         open = !open;
@@ -63,20 +63,15 @@
         </button>
     </div>
 </form>
+<script>
+    document.getElementById('river-image-upload').onchange = function () {
+        let src = URL.createObjectURL(this.files[0])
+        document.getElementById('image-preview').src = src
+    }
+</script>
 {% endblock %}
 
 
-{% block scripts %}
-
-    <script>
-        document.getElementById('river-image-upload').onchange = function () {
-            let src = URL.createObjectURL(this.files[0])
-            document.getElementById('image-preview').src = src
-        }
-    </script>
-
-
-{% endblock %}
 
 
 

--- a/templates/river/partials/river-settings.html
+++ b/templates/river/partials/river-settings.html
@@ -1,6 +1,6 @@
 {% load custom_filters %}
-<section
-        class="z-20 flex justify-center items-center flex-col h-full w-full fixed left-0 top-0 backdrop-blur bg-blue-blur">
+<section class="z-20 flex justify-center items-center flex-col h-full w-full fixed left-0 top-0 backdrop-blur bg-blue-blur"
+         @click="el => { if (el.target.classList.contains('backdrop-blur')) { open = false } }">
     <div class="bg-white mx-2.5 px-5 w-[90vw] sm:w-[336px]">
         {% include "partials/vertical-spacer.html" with space="7.5" %}
         <h2 class="text-large text-center">
@@ -28,7 +28,7 @@
 
                 <div x-data="{ editing: false }">
 
-                    <button x-on:click="()=> { editing = !editing; }"
+                    <button @click="()=> { editing = !editing; }"
                             type="button"
                             class="button button-on-white">
                         Edit River title
@@ -41,7 +41,7 @@
 
                 <div x-data="{ editing: false }">
 
-                    <button x-on:click="()=> { editing = !editing; }"
+                    <button @click="()=> { editing = !editing; }"
                             type="button"
                             class="button button-on-white">
                         Edit River description
@@ -55,7 +55,7 @@
 
             <div x-data="{ editing: false }">
 
-                <button x-on:click="()=> { editing = !editing; }"
+                <button @click="()=> { editing = !editing; }"
                         type="button"
                         class="button button-on-white">
                     Edit River image
@@ -83,7 +83,7 @@
         {# {% endif %} #}
 
         {% include "partials/vertical-spacer.html" with space="7.5" %}
-        <button onclick="enableBodyScroll();" x-on:click="open = ! open"
+        <button @click="open = false"
                 type="button"
                 class="button button-on-white">
             Back

--- a/templates/river/partials/river-title-change.html
+++ b/templates/river/partials/river-title-change.html
@@ -1,57 +1,54 @@
-{% extends "partials/overlay-river.html"%}
+{% extends "partials/overlay-river-closable.html"%}
 {% block overlay_title %}Change River title{% endblock %}
 {% load static %}
 
-
 {% block river_overlay_content %}
-    {{ overlay_title }}
+    <form hx-put="{% url 'edit_river' river.slug %}" hx-target="#river-title" hx-swap="innerHTML" class="mb-0">
 
-        <form hx-put="{% url 'edit_river' river.slug %}" hx-target="#river-title" hx-swap="innerHTML" class="mb-0">
+        {% csrf_token %}
 
-            {% csrf_token %}
+        {% include "partials/input-label.html" with for="title" label="New River title" %}
+        <input id=river-title-input name=title type=text placeholder="{{ river.title }}" value=""
+               pattern="[a-zA-Z][a-zA-Z\s]*"
+               class="input-text input-text-invalid">
+        {% include "partials/vertical-spacer.html" with space="1.5" %}
+        {% include "partials/input-note.html" with for="title" label="You can change river title until you create the poll" %}
+        {% include "partials/vertical-spacer.html" with space="4.5" %}
+        <div class="flex items-center justify-center">
+            <button @click="editing = !editing"
+                    type="button"
+                    class="button button-on-white">
+                Back
+            </button>
+            {% include "partials/horizontal-spacer.html" with space="4.5" %}
+            {% comment %}
+           TODO: Need to use multi-swap: https://htmx.org/extensions/multi-swap/
+           document.getElementById('river-title').innerHTML=document.getElementById('river-title-input').value;
 
-            {% include "partials/input-label.html" with for="title" label="New River title" %}
-            <input id=river-title-input name=title type=text placeholder="{{ river.title }}" value=""
-                   pattern="[a-zA-Z][a-zA-Z\s]*"
-                   class="input-text input-text-invalid">
-            {% include "partials/vertical-spacer.html" with space="1.5" %}
-            {% include "partials/input-note.html" with for="title" label="You can change river title until you create the poll" %}
-            {% include "partials/vertical-spacer.html" with space="4.5" %}
-            <div class="flex items-center justify-center">
-                <button x-on:click="editing = !editing"
-                        type="button"
-                        class="button button-on-white">
-                    Back
-                </button>
-                {% include "partials/horizontal-spacer.html" with space="4.5" %}
-                {% comment %}
-               TODO: Need to use multi-swap: https://htmx.org/extensions/multi-swap/
-               document.getElementById('river-title').innerHTML=document.getElementById('river-title-input').value;
+           {% endcomment %}
+            <button
+                    @click="()=>{
+                    enableBodyScroll();
+                    //remove settings
+                    open = !open;
 
-               {% endcomment %}
-                <button
-                        x-on:click="()=>{
-                        enableBodyScroll();
-                        //remove settings
-                        open = !open;
+                    // editing unblock
+                    editing = !editing;
 
-                        // editing unblock
-                        editing = !editing;
+                    //aligning input with placeholder in case someone wants to change again
+                    var titleInput = document.getElementById('river-title-input')
+                    titleInput.placeholder = titleInput.value
+                    setTimeout(()=>{
+                        titleInput.value = ''
+                    }, 500)
 
-                        //aligning input with placeholder in case someone wants to change again
-                        var titleInput = document.getElementById('river-title-input')
-                        titleInput.placeholder = titleInput.value
-                        setTimeout(()=>{
-                            titleInput.value = ''
-                        }, 500)
+                    }"
+                    type="submit"
+                    class="button button-on-white">
 
-                        }"
-                        type="submit"
-                        class="button button-on-white">
-
-                    Submit
-                </button>
-            </div>
-        </form>
+                Submit
+            </button>
+        </div>
+    </form>
 
 {% endblock %}

--- a/templates/river/river.html
+++ b/templates/river/river.html
@@ -40,11 +40,11 @@
                             {#                <p><a href="{% url 'manage_river' object.slug %}">Manage River</a></p>#}
 
                             {% if request.user in members|attrmap:'user' %}
-                                <div x-data="{ open: false }">
-                                    <button onclick="stopBodyScroll();"
-                                            type="button"
+                                <div x-data="{ open: false }"
+                                     x-stop-body-scroll-if="open">
+                                    <button type="button"
                                             {% comment %}TODO: htmx returned partial does not gel with alpine{% endcomment %}
-                                            x-on:click="()=>{ open = !open;
+                                            @click="()=>{ open = !open;
                                         if (!document.getElementById('title-change').classList.contains('hidden')) {
                                             document.getElementById('title-change').classList.add('hidden');
                                         }
@@ -73,13 +73,6 @@
 
                     {% include "partials/vertical-spacer.html" with space="3" %}
 
-                    {# CTA for rivers without enough swimmers to splash with. Show if riverstarter, and if count swimmers <3 #}
-                    {% if request.user in starters|attrmap:'user' and members.count < 3 %}
-                        <section class="-mx-4.5 bg-resources-two">
-                            {% include 'partials/call-to-action-copy.html' with text='Share' icon='link' %}
-                        </section>
-                    {% endif %}
-
                     {# River information; swimmers, description #}
                     <section class="-mx-4.5 lg:mx-0">
                         {% include "river/swimmers.html" with title="swimmers" reference="swimmers" id="swimmers" selected="null" %}
@@ -98,6 +91,15 @@
 
                 {# River information; stage bookmarks, resources. At end so knowledge salmon is always on top #}
                 <section class="-mx-4.5 lg:mx-0 col-span-1 lg:justify-items-end"> {# Large layout, last column #}
+
+
+                    {# CTA for rivers without enough swimmers to splash with. Show if riverstarter, and if count swimmers <3 #}
+                    {% if request.user in starters|attrmap:'user' and members.count < 3 %}
+                        <section class="-mx-4.5 bg-resources-two mb-6">
+                            {% include 'partials/call-to-action-copy.html' with text='Share' icon='link' %}
+                        </section>
+                    {% endif %}
+
                     {# Stage outline #}
                     <ul class="hidden lg:flex flex-col gap-3 text-right">
                         <li><a href="#envision" class="button button-on-white button-secondary">Envision</a></li>

--- a/templates/river/river_card.html
+++ b/templates/river/river_card.html
@@ -9,8 +9,10 @@
     <div class="p-3 relative">
         <div class="">
             <div class="flex flex-start justify-between -mr-4.5">
-                <h2 class="relative text-title text-black/55">
-                    {{ river.title }}
+                <h2 class="relative text-title text-black/55 grow">
+                    <a href="{{ view_url }}" class="block">
+                        {{ river.title }}
+                    </a>
                 </h2>
                 <div class="-my-3">{% include 'partials/button-copy.html' with icon='link' path=view_url %}</div>
             </div>

--- a/templates/river/start_river.html
+++ b/templates/river/start_river.html
@@ -11,63 +11,66 @@
 
 {% block content %}
     {% block title %}{% include "partials/title.html" with title='Start a River' %}{% endblock %}
-    {% include "partials/vertical-spacer.html" with space="3" %}
-
-    <form method="post" enctype="multipart/form-data" class="m-0 px-4.5">
-        {% csrf_token %}
-        {% include "partials/input-label.html" with for="id_title" label="Title" %}
-        {% render_field form.title class="input-text" %}
-
-        {% include "partials/vertical-spacer.html" with space="9" %}
-
-        {% include "partials/input-label.html" with for="id_description" label="Description" %}
-        {% render_field form.description class="input-text" %}
-
-        {% include "partials/vertical-spacer.html" with space="9" %}
-        <div class="inline-block">
-            {% include "partials/input-label.html" with for="id_tags" label="Tags" %}
-        </div>
-        <span class="text-header text-black/30 pl-2" id="counter">choose 3</span>
+    <div class="max-w-screen-xl mx-auto">
         {% include "partials/vertical-spacer.html" with space="3" %}
-        <div class="flex flex-wrap gap-5 -m-1">
-            {% if tags %}
-                {% for tag in tags %}
-                    {% with counter=forloop.counter0 %}
 
-                        <button id="button-{{ counter }}"
-                                onclick="event.preventDefault(); selectTag(this.id, '{{ tag }}')"
-                                class="px-1.5 py-1 bg-blue-pale rounded-sm">
-                            <span class="text-meta-label text-black/55 uppercase leading-none whitespace-normal">{{ tag }}</span>
-                        </button>
-                    {% endwith %}
+        <form method="post" enctype="multipart/form-data" class="m-0 px-4.5">
+            {% csrf_token %}
+            {% include "partials/input-label.html" with for="id_title" label="Title" %}
+            {% render_field form.title class="input-text" %}
 
-                {% endfor %}
-            {% endif %}
-        </div>
-        {% include "partials/vertical-spacer.html" with space="12" %}
-        {% include "partials/input-label.html" with for="id_image" label="Upload an image" %}
-        <div class="text-meta text-black/30">
-            {% render_field form.image %}
-        </div>
+            {% include "partials/vertical-spacer.html" with space="9" %}
 
-        <input id="tags_input" name=tags type=text value="" class="hidden">
+            {% include "partials/input-label.html" with for="id_description" label="Description" %}
+            {% render_field form.description class="input-text" %}
 
-        {% comment %}            <textarea name=message></textarea>
-            <input type="file" id="image" name="image">{% endcomment %}
-        {% include "partials/vertical-spacer.html" with space="9" %}
+            {% include "partials/vertical-spacer.html" with space="9" %}
+            <div class="inline-block">
+                {% include "partials/input-label.html" with for="id_tags" label="Tags" %}
+            </div>
+            <span class="text-header text-black/30 pl-2" id="counter">choose 3</span>
+            {% include "partials/vertical-spacer.html" with space="3" %}
+            <div class="flex flex-wrap gap-5 -m-1">
+                {% if tags %}
+                    {% for tag in tags %}
+                        {% with counter=forloop.counter0 %}
 
-        <p class="text-black-text">
-            NB: All new rivers start at the Envision stage. Future stages remain
-            locked until a successful (i.e. majority YES) Poll takes place.
-        </p>
-        {% include "partials/vertical-spacer.html" with space="9" %}
+                            <button id="button-{{ counter }}"
+                                    onclick="event.preventDefault(); selectTag(this.id, '{{ tag }}')"
+                                    class="px-1.5 py-1 bg-blue-pale rounded-sm">
+                                <span class="text-meta-label text-black/55 uppercase leading-none whitespace-normal">{{ tag }}</span>
+                            </button>
+                        {% endwith %}
 
-        <button class="button button-important" type="submit">
-            Publish
-        </button>
-    </form>
+                    {% endfor %}
+                {% endif %}
+            </div>
+            {% include "partials/vertical-spacer.html" with space="12" %}
+            {% include "partials/input-label.html" with for="id_image" label="Upload an image" %}
+            <div class="text-meta text-black/30">
+                {% render_field form.image %}
+            </div>
 
-    {% include "partials/vertical-spacer.html" with space="6" %}
+            <input id="tags_input" name=tags type=text value="" class="hidden">
+
+            {% comment %}            <textarea name=message></textarea>
+                <input type="file" id="image" name="image">{% endcomment %}
+            {% include "partials/vertical-spacer.html" with space="9" %}
+
+            <p class="text-black-text">
+                NB: All new rivers start at the Envision stage. Future stages remain
+                locked until a successful (i.e. majority YES) Poll takes place.
+            </p>
+            {% include "partials/vertical-spacer.html" with space="9" %}
+
+            <button class="button button-important" type="submit">
+                Publish
+            </button>
+        </form>
+
+        {% include "partials/vertical-spacer.html" with space="6" %}
+
+    </div>
 
     {% block scripts %}
         {% vite_asset 'templates/river/ts/start_river.ts' %}

--- a/templates/ts/directives/stop-body-scroll.ts
+++ b/templates/ts/directives/stop-body-scroll.ts
@@ -6,6 +6,25 @@ import { enableBodyScroll, stopBodyScroll } from "@/templates/ts/scroll.ts"
 // TODO: this could alternatively be done in scroll.ts, and would then work for non-directive uses too
 let count = 0
 
+function inc() {
+    if (count === 0) {
+        // Going from 0 to >0, means we need to stop it
+        stopBodyScroll()
+    }
+    count++
+}
+
+function dec() {
+    count--
+    if (count < 0) {
+        count = 0
+    }
+    if (count === 0) {
+        // Going from >0 to 0 means we need to re-enable it again
+        enableBodyScroll()
+    }
+}
+
 /**
  * A directive to stop body scroll while this element is present. When the element
  * is removed, scroll will be restored again.
@@ -25,17 +44,44 @@ Alpine.directive('stop-body-scroll', (
     // This means we are not displayed on the page (e.g. a parent is display: none), so
     // it means it's likely being used via hiding/showing an element, not adding/removing
     // an element. This directive only supports the adding/removing element use case.
-    // If used by hiding/showing the element, you have to manage the body scroll yourself...
+    // If used by hiding/showing the element, you have to manage the body scroll yourself
+    // or use x-stop-body-scroll-if="condition"
     if (!el.offsetParent) return
+    inc()
+    cleanup(() => dec())
+})
 
-    if (count === 0) {
-        stopBodyScroll()
-    }
-    count += 1
+/**
+ * A directive to stop body scroll while a condition is true.
+ *
+ * The purpose is for things like modals/menus/etc. that are shown/hidden, e.g. using x-show
+ * rather than the element being present or not.
+ *
+ * Usage:
+ *
+ *  <div x-stop-body-scroll-if="open"></div>
+ */
+Alpine.directive('stop-body-scroll-if', (
+    _,
+    { expression },
+    { evaluateLater, effect, cleanup },
+) => {
+    const getValue = evaluateLater(expression)
+    let stop = false
+    effect(() => {
+        getValue(raw => {
+            const value = Boolean(raw)
+            if (value) {
+                inc()
+            } else {
+                // Only act if we previously have stopped scroll with this element
+                // (avoids calling dec() when first initialized)
+                if (stop) dec()
+            }
+            stop = value
+        })
+    })
     cleanup(() => {
-        count -= 1
-        if (count === 0) {
-            enableBodyScroll()
-        }
+        if (stop) dec()
     })
 })

--- a/templates/ts/screen.ts
+++ b/templates/ts/screen.ts
@@ -7,7 +7,9 @@
  * If reactivity is needed, could use https://alpinejs.dev/advanced/reactivity
  */
 
-const matchMediaDesktop = window.matchMedia('(min-width: 1024px)');
+const desktop = '1024px'
+
+const matchMediaDesktop = window.matchMedia(`(min-width: ${desktop})`);
 
 const screen = {
     isDesktop: matchMediaDesktop.matches,

--- a/templates/userauth/account/view.html
+++ b/templates/userauth/account/view.html
@@ -284,8 +284,6 @@
 
         </section>
 
-
-        {% include "partials/footer-gradient.html" %}
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Following walkthrough with Eszter...

Improvements:
- funder/sponsor logo margin
- responsive contact us form 
- fix flickity carousel dot positioning/styling
- fix landing page video height
- menu background blur
- landing page side-by-side info boxes
- landing page, left aligned tabs
- menu scrolls when overflowing
- menu burger menu shows inside title header
- all modals closed when clicking on the overlay
- fix: dashboard page shows correct "Your status" info
- can click river title on spring page to enter river
- attachment success tick is now green, not red
- confirm dialog and when flagging messages, and message when complete
- chatbox input full width + aligned with messages + white space above input removed
- "start a river" form not full screen width
- river page, "you need to find more swimmers" now on the right
- profile page, removed massive grey footer
- river image editing: fix modal title + image preview

Not completed, but could be future improvements:
- make these pages not full page width:
 - "check your email"
  - change your password
  - delete my account
- messages page
  - each chat message is narrow, and on the side
  - ideal to have other chats on the side, but ok if just messages...

